### PR TITLE
Add hack to get AWE tests to pass

### DIFF
--- a/src/us/kbase/userandjobstate/test/awe/controller/AweController.java
+++ b/src/us/kbase/userandjobstate/test/awe/controller/AweController.java
@@ -116,6 +116,8 @@ public class AweController {
 			final Path rootTempDir)
 			throws Exception {
 		this.shockURL = shockURL;
+		Thread.sleep(1000); //wait for shock to start 
+		//TODO add a sleep to the shock controller post start rather than sleeping here
 		new BasicShockClient(shockURL); // check url
 		tempDir = makeTempDirs(rootTempDir, "AweController-", tempDirectories)
 				.toAbsolutePath();


### PR DESCRIPTION
Add a 1s delay before starting AWE to allow mongo/shock to start up.
Seems to fix the problem, but it was intermittent so can't be sure.
