### PR TITLE
Allow deleting jobs for workspace administrators

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -31,12 +31,16 @@ NEW FEATURES:
 - Added the create_job2, get_job_info2, and list_jobs2 methods which can
   accept or return an authorization strategy and parameter(s). create_job,
   get_job_info, and list_jobs are now deprecated.
+- Jobs can now be canceled, which puts them in a canceled state. Canceled jobs
+  may not be altered further other than deletion. The user that canceled the
+  job is returned by get_job_info2. Users with write access to a workspace can
+  cancel jobs associated with that workspace.
+- Users with administrative access to a workspace can delete jobs associated
+  with that workspace when those jobs are in the error, complete, or canceled
+  state.
 - User specified metadata can now be associated with a job via the create_job2
   method.
 - These is now a minimal documentation server at the /docs endpoint.
-- Jobs can now be canceled, which puts them in a canceled state. Canceled jobs
-  may not be altered further. The user that canceled the job is returned by
-  get_job_info2.
 
 UPDATED FEATURES / MAJOR BUG FIXES:
 

--- a/src/us/kbase/userandjobstate/UserAndJobStateServer.java
+++ b/src/us/kbase/userandjobstate/UserAndJobStateServer.java
@@ -230,7 +230,7 @@ public class UserAndJobStateServer extends JsonServerServlet {
 				final String user,
 				final Job j)
 				throws UJSAuthorizationException {
-			checkStrat(j.getAuthorizationStrategy()); //TODO NOW TEST
+			checkStrat(j.getAuthorizationStrategy());
 		}
 	};
 	
@@ -1441,7 +1441,7 @@ public class UserAndJobStateServer extends JsonServerServlet {
     @JsonServerMethod(rpc = "UserAndJobState.delete_job", async=true)
     public void deleteJob(String job, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         //BEGIN delete_job
-		js.deleteJob(authPart.getUserName(), job, getAuthorizer(authPart)); // TODO NOW TEST
+		js.deleteJob(authPart.getUserName(), job, getAuthorizer(authPart));
         //END delete_job
     }
 
@@ -1460,7 +1460,7 @@ public class UserAndJobStateServer extends JsonServerServlet {
     public void forceDeleteJob(String token, String job, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         //BEGIN force_delete_job
 		js.deleteJob(authPart.getUserName(), job, getServiceUserName(token),
-				getAuthorizer(authPart)); //TODO NOW TEST
+				getAuthorizer(authPart));
         //END force_delete_job
     }
     @JsonServerMethod(rpc = "UserAndJobState.status")

--- a/src/us/kbase/userandjobstate/UserAndJobStateServer.java
+++ b/src/us/kbase/userandjobstate/UserAndJobStateServer.java
@@ -222,7 +222,15 @@ public class UserAndJobStateServer extends JsonServerServlet {
 				final String user,
 				final Job j)
 				throws UJSAuthorizationException {
-			checkStrat(j.getAuthorizationStrategy()); //TODO NOW TEST 
+			checkStrat(j.getAuthorizationStrategy());
+		}
+
+		@Override
+		protected void externallyAuthorizeDelete(
+				final String user,
+				final Job j)
+				throws UJSAuthorizationException {
+			checkStrat(j.getAuthorizationStrategy()); //TODO NOW TEST
 		}
 	};
 	

--- a/src/us/kbase/userandjobstate/UserAndJobStateServer.java
+++ b/src/us/kbase/userandjobstate/UserAndJobStateServer.java
@@ -1441,7 +1441,7 @@ public class UserAndJobStateServer extends JsonServerServlet {
     @JsonServerMethod(rpc = "UserAndJobState.delete_job", async=true)
     public void deleteJob(String job, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         //BEGIN delete_job
-		js.deleteJob(authPart.getUserName(), job);
+		js.deleteJob(authPart.getUserName(), job, getAuthorizer(authPart)); // TODO NOW TEST
         //END delete_job
     }
 
@@ -1459,7 +1459,8 @@ public class UserAndJobStateServer extends JsonServerServlet {
     @JsonServerMethod(rpc = "UserAndJobState.force_delete_job", async=true)
     public void forceDeleteJob(String token, String job, AuthToken authPart, RpcContext jsonRpcContext) throws Exception {
         //BEGIN force_delete_job
-		js.deleteJob(authPart.getUserName(), job, getServiceUserName(token));
+		js.deleteJob(authPart.getUserName(), job, getServiceUserName(token),
+				getAuthorizer(authPart)); //TODO NOW TEST
         //END force_delete_job
     }
     @JsonServerMethod(rpc = "UserAndJobState.status")

--- a/src/us/kbase/userandjobstate/authorization/DefaultUJSAuthorizer.java
+++ b/src/us/kbase/userandjobstate/authorization/DefaultUJSAuthorizer.java
@@ -36,9 +36,13 @@ public class DefaultUJSAuthorizer extends UJSAuthorizer {
 	}
 
 	@Override
-	protected void externallyAuthorizeCancel(
-			final String user,
-			final Job j)
+	protected void externallyAuthorizeCancel(final String user, final Job j)
+			throws UJSAuthorizationException {
+		throw new UnimplementedException();
+	}
+
+	@Override
+	protected void externallyAuthorizeDelete(final String user, final Job j)
 			throws UJSAuthorizationException {
 		throw new UnimplementedException();
 	}

--- a/src/us/kbase/userandjobstate/authorization/UJSAuthorizer.java
+++ b/src/us/kbase/userandjobstate/authorization/UJSAuthorizer.java
@@ -174,6 +174,38 @@ public abstract class UJSAuthorizer {
 			final String user,
 			final Job j)
 			throws UJSAuthorizationException;
-
 	
+	/** Authorize deleting a job.
+	 * @param user the user requesting authorization.
+	 * @param j the job requiring authorization.
+	 * @throws UJSAuthorizationException if authorization is denied.
+	 */
+	public void authorizeDelete(
+			final String user,
+			final Job j)
+			throws UJSAuthorizationException {
+		checkUser(user);
+		if (j == null) {
+			throw new NullPointerException("job cannot be null");
+		}
+		if (j.getAuthorizationStrategy().equals(DEFAULT_AUTH_STRAT)) {
+			if (!user.equals(j.getUser())) {
+				throw new UJSAuthorizationException(String.format(
+						"User %s may not delete job %s", user, j.getID()));
+			}
+		} else {
+			externallyAuthorizeDelete(user, j);
+		}
+	}
+	
+	/** Authorize deleting a job using a non-default authorization source.
+	 * @param user the user requesting authorization.
+	 * @param j the job requiring authorization.
+	 * @throws UJSAuthorizationException if authorization is denied.
+	 */
+	protected abstract void externallyAuthorizeDelete(
+			final String user,
+			final Job j)
+			throws UJSAuthorizationException;
+
 }

--- a/src/us/kbase/userandjobstate/jobstate/JobState.java
+++ b/src/us/kbase/userandjobstate/jobstate/JobState.java
@@ -671,7 +671,7 @@ public class JobState {
 	private String completeQuery(
 			String queryPrefix,
 			final boolean running,
-			final boolean complete, //TODO NOW
+			final boolean complete,
 			final boolean canceled,
 			final boolean error) {
 		/* TODO ZZLATER should have a indexed state variable in the job db doc 

--- a/src/us/kbase/userandjobstate/jobstate/JobState.java
+++ b/src/us/kbase/userandjobstate/jobstate/JobState.java
@@ -556,15 +556,15 @@ public class JobState {
 				jobID, user +
 				(service == null ? "" : " and service " + service)));
 		
-		String querystr = String.format("{%s: #, %s: #, ", USER, MONGO_ID);
+		String querystr = String.format("{%s: #, ", MONGO_ID);
 		final Job j;
 		try {
 			if (service == null) {
 				querystr += String.format("%s: true}", COMPLETE);
-				j = jobjong.findOne(querystr, user, id).as(Job.class);
+				j = jobjong.findOne(querystr, id).as(Job.class);
 			} else {
 				querystr += String.format("%s: #}", SERVICE);
-				j = jobjong.findOne(querystr, user, id, service).as(Job.class);
+				j = jobjong.findOne(querystr, id, service).as(Job.class);
 			}
 		} catch (MongoException me) {
 			throw new CommunicationException(
@@ -579,8 +579,7 @@ public class JobState {
 			throw err;
 		}
 		
-		final DBObject query = new BasicDBObject(USER, user);
-		query.put(MONGO_ID, id);
+		final DBObject query = new BasicDBObject(MONGO_ID, id);
 		if (service == null) {
 			query.put(COMPLETE, true);
 		} else {

--- a/src/us/kbase/userandjobstate/kbase/WorkspaceAuthorizationFactory.java
+++ b/src/us/kbase/userandjobstate/kbase/WorkspaceAuthorizationFactory.java
@@ -237,7 +237,7 @@ public class WorkspaceAuthorizationFactory {
 		}
 		
 		@Override
-		protected void externallyAuthorizeDelete( //TODO NOW TEST
+		protected void externallyAuthorizeDelete(
 				final String user,
 				final Job j)
 				throws UJSAuthorizationException {

--- a/src/us/kbase/userandjobstate/kbase/WorkspaceAuthorizationFactory.java
+++ b/src/us/kbase/userandjobstate/kbase/WorkspaceAuthorizationFactory.java
@@ -92,6 +92,7 @@ public class WorkspaceAuthorizationFactory {
 				Collections.unmodifiableList(Arrays.asList("r", "w", "a"));
 		private static final List<String> CAN_WRITE =
 				Collections.unmodifiableList(Arrays.asList("w", "a"));
+		private static final String ADMIN = "a";
 		private static final int MAX_WS_COUNT = 10;
 		
 		private WorkspaceClient client;
@@ -235,6 +236,25 @@ public class WorkspaceAuthorizationFactory {
 			}
 		}
 		
+		@Override
+		protected void externallyAuthorizeDelete( //TODO NOW TEST
+				final String user,
+				final Job j)
+				throws UJSAuthorizationException {
+			checkWSUser(user);
+			checkStrat(j.getAuthorizationStrategy());
+			if (user.equals(j.getUser())) {
+				return; // owner can always delete job
+			}
+			final String p = getPerms(j.getAuthorizationParameter())
+					.get(0).get(username);
+			if (!ADMIN.equals(p)) {
+				throw new UJSAuthorizationException(String.format(
+						"User %s does not have administration privileges " +
+						"for workspace %s",
+						username, j.getAuthorizationParameter()));
+			}
+		}
 	}
 
 }

--- a/src/us/kbase/userandjobstate/test/jobstate/JobStateTests.java
+++ b/src/us/kbase/userandjobstate/test/jobstate/JobStateTests.java
@@ -248,7 +248,6 @@ public class JobStateTests {
 				}
 			}
 			
-			//TODO NOW TEST
 			@Override
 			protected void externallyAuthorizeDelete(String user, Job j)
 				throws UJSAuthorizationException {
@@ -298,7 +297,16 @@ public class JobStateTests {
 				new NoSuchJobException(String.format(
 						"There is no job %s viewable by user %s", id2, user)));
 		
-		//test fail canceling jobs with alternate auth
+		//test  canceling jobs with alternate auth
+		String canok = js.createJob(user, lenientauth,
+				new AuthorizationStrategy("strat1"), "cancel", mt);
+		js.cancelJob(user, canok, "foo", lenientauth);
+		Job j = js.getJob(user, canok, lenientauth);
+		checkJob(j, canok, "canceled", null, user, user, "foo", null, null,
+				null, null, null, true, false, null, null, null,
+				new AuthorizationStrategy("strat1"), "cancel",
+				mt.getMetadata());
+		
 		String id4 = js.createJob(user, lenientauth,
 				new AuthorizationStrategy("strat1"), "fail cancel", mt);
 		js.startJob(user, id4, "s", "stat", "desc", null);
@@ -307,6 +315,22 @@ public class JobStateTests {
 				new NoSuchJobException(String.format(
 						"There is no job %s that may be canceled by user %s",
 						id4, user)));
+		
+		//test deleting jobs with alternate auth
+		String delok = js.createJob(user, lenientauth,
+				new AuthorizationStrategy("strat1"), "delete", mt);
+		js.startJob(user, delok, "s", "stat", "desc", null);
+		js.completeJob(user, delok, "s", "stat1", null, null);
+		succeedAtDeletingJob(user, delok, lenientauth);
+		
+		String id5 = js.createJob(user, lenientauth,
+				new AuthorizationStrategy("strat1"), "fail delete", mt);
+		js.startJob(user, id5, "s", "stat", "desc", null);
+		failToDeleteJob(user, id5, "s", new UnimplementedException());
+		failToDeleteJob(user, id5, "s", lenientauth,
+				new NoSuchJobException(String.format(
+						"There is no deletable job %s for user %s and service s",
+						id5, user)));
 		
 		//test listing jobs with alternate auth
 			// start & create some jobs
@@ -1151,46 +1175,71 @@ public class JobStateTests {
 	
 	@Test
 	public void deleteJob() throws Exception {
-		String jobid = js.createAndStartJob("delete", "serv1", "st", "dsc",
+		final String user = "delete";
+		String jobid = js.createAndStartJob(user, "serv1", "st", "dsc",
 				null);
-		js.completeJob("delete", jobid, "serv1", "st", null, null);
-		Job j = js.getJob("delete", jobid); //should work
-		checkJob(j, jobid, "complete", null, "delete", null, "st", "serv1",
+		js.completeJob(user, jobid, "serv1", "st", null, null);
+		Job j = js.getJob(user, jobid); //should work
+		checkJob(j, jobid, "complete", null, user, null, "st", "serv1",
 				"dsc", "none", null, null, true, false, null, null);
-		succeedAtDeletingJob("delete", jobid);
-		failToDeleteJob("delete", jobid, null);
+		succeedAtDeletingJob(user, jobid);
+		failToDeleteJob(user, jobid, null, new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s",
+						jobid, user)));
 		
-		jobid = js.createJob("delete");
-		failToDeleteJob("delete", jobid, null);
-		js.startJob("delete", jobid, "s", "s", "d", null);
-		failToDeleteJob("delete", jobid, null);
-		js.updateJob("delete", jobid, "s", "s", 1, null);
-		failToDeleteJob("delete", jobid, null);
-		failToDeleteJob("delete1", jobid, null);
-		failToDeleteJob("delete", "a" + jobid.substring(1), null);
+		jobid = js.createJob(user);
+		NoSuchJobException err = new NoSuchJobException(String.format(
+				"There is no deletable job %s for user %s", jobid, user));
+		failToDeleteJob(user, jobid, null, err);
+		js.startJob(user, jobid, "s", "s", "d", null);
+		failToDeleteJob(user, jobid, null, err);
+		js.updateJob(user, jobid, "s", "s", 1, null);
+		failToDeleteJob(user, jobid, null, err);
+		failToDeleteJob(user + "1", jobid, null, new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s",
+						jobid, user + "1")));
+		failToDeleteJob(user, "a" + jobid.substring(1), null,
+				new NoSuchJobException(String.format(
+						"There is no deletable job %s for user %s",
+						"a" + jobid.substring(1), user)));
 		
-		failToDeleteJob("delete1", jobid, "serv1");
-		failToDeleteJob("delete", "a" + jobid.substring(1), "serv1");
+		failToDeleteJob(user + "1", jobid, "serv1", new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s " +
+						"and service serv1", jobid, user + "1")));
+		failToDeleteJob(user, "a" + jobid.substring(1), "serv1",
+				new NoSuchJobException(String.format(
+						"There is no deletable job %s for user %s " +
+						"and service serv1", "a" + jobid.substring(1), user)));
 		
-		jobid = js.createJob("delete");
+		jobid = js.createJob(user);
 //		succeedAtDeletingJob("delete", jobid, "serv1");
-		failToDeleteJob("delete", jobid, "serv1");
-		jobid = js.createAndStartJob("delete", "serv1", "st", "dsc", null);
-		succeedAtDeletingJob("delete", jobid, "serv1");
-		failToDeleteJob("delete", jobid, "serv1");
-		jobid = js.createAndStartJob("delete", "serv1", "st", "dsc", null);
-		js.updateJob("delete", jobid, "serv1", "st", null, null);
-		succeedAtDeletingJob("delete", jobid, "serv1");
-		failToDeleteJob("delete", jobid, "serv1");
-		jobid = js.createAndStartJob("delete", "serv1", "st", "dsc", null);
-		js.completeJob("delete", jobid, "serv1", "st", null, null);
-		succeedAtDeletingJob("delete", jobid, "serv1");
-		failToDeleteJob("delete", jobid, "serv1");
+		failToDeleteJob(user, jobid, "serv1", new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s " +
+						"and service serv1", jobid, user)));
+		jobid = js.createAndStartJob(user, "serv1", "st", "dsc", null);
+		succeedAtDeletingJob(user, jobid, "serv1");
+		failToDeleteJob(user, jobid, "serv1", new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s " +
+						"and service serv1", jobid, user)));
+		jobid = js.createAndStartJob(user, "serv1", "st", "dsc", null);
+		js.updateJob(user, jobid, "serv1", "st", null, null);
+		succeedAtDeletingJob(user, jobid, "serv1");
+		failToDeleteJob(user, jobid, "serv1", new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s " +
+						"and service serv1", jobid, user)));
+		jobid = js.createAndStartJob(user, "serv1", "st", "dsc", null);
+		js.completeJob(user, jobid, "serv1", "st", null, null);
+		succeedAtDeletingJob(user, jobid, "serv1");
+		failToDeleteJob(user, jobid, "serv1", new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s " +
+						"and service serv1", jobid, user)));
 		
-		jobid = js.createAndStartJob("delete", "serv1", "st", "dsc", null);
-		js.cancelJob("delete", jobid, "cancel");
-		succeedAtDeletingJob("delete", jobid);
-		failToDeleteJob("delete", jobid, "serv1");
+		jobid = js.createAndStartJob(user, "serv1", "st", "dsc", null);
+		js.cancelJob(user, jobid, "cancel");
+		succeedAtDeletingJob(user, jobid);
+		failToDeleteJob(user, jobid, "serv1", new NoSuchJobException(
+				String.format("There is no deletable job %s for user %s " +
+						"and service serv1", jobid, user)));
 		
 	}
 	
@@ -1215,9 +1264,19 @@ public class JobStateTests {
 		}
 	}
 	
-	private void succeedAtDeletingJob(String user, String jobid)
+	private void succeedAtDeletingJob(
+			final String user,
+			final String jobid)
 			throws Exception {
-		js.deleteJob(user, jobid);
+		succeedAtDeletingJob(user, jobid, new DefaultUJSAuthorizer());
+	}
+	
+	private void succeedAtDeletingJob(
+			final String user,
+			final String jobid,
+			final UJSAuthorizer auth)
+			throws Exception {
+		js.deleteJob(user, jobid, auth);
 		try {
 			js.getJob(user, jobid);
 			fail("got deleted job");
@@ -1236,29 +1295,34 @@ public class JobStateTests {
 		}
 	}
 	
-	private void failToDeleteJob(String user, String jobid, String service)
-			throws Exception {
+	private void failToDeleteJob(
+			final String user,
+			final String jobid,
+			final String service,
+			final Exception exp) {
+		failToDeleteJob(user, jobid, service, new DefaultUJSAuthorizer(), exp);
+	}
+	
+	private void failToDeleteJob(
+			final String user,
+			final String jobid,
+			final String service,
+			final UJSAuthorizer auth,
+			final Exception exp) {
 		try {
-			js.deleteJob(user, jobid, service);
+			js.deleteJob(user, jobid, service, auth);
 			fail("deleted job when should've failed");
-		} catch (NoSuchJobException nsje) {
-			assertThat("correct exception msg", nsje.getLocalizedMessage(),
-					is(String.format(
-					"There is no %sjob %s for user %s",
-					service == null ? "completed " : "", jobid, user +
-					(service == null ? "" : " and service " + service))));
+		} catch (Exception got) {
+			assertExceptionCorrect(got, exp);
 		}
 		if (service != null) {
 			return;
 		}
 		try {
-			js.deleteJob(user, jobid);
+			js.deleteJob(user, jobid, auth);
 			fail("deleted job when should've failed");
-		} catch (NoSuchJobException nsje) {
-			assertThat("correct exception msg", nsje.getLocalizedMessage(),
-					is(String.format(
-					"There is no completed job %s for user %s",
-					jobid, user)));
+		} catch (Exception got) {
+			assertExceptionCorrect(got, exp);
 		}
 	}
 	

--- a/src/us/kbase/userandjobstate/test/jobstate/JobStateTests.java
+++ b/src/us/kbase/userandjobstate/test/jobstate/JobStateTests.java
@@ -247,6 +247,15 @@ public class JobStateTests {
 					throw new UJSAuthorizationException("fail cancel req");
 				}
 			}
+			
+			//TODO NOW TEST
+			@Override
+			protected void externallyAuthorizeDelete(String user, Job j)
+				throws UJSAuthorizationException {
+				if ("fail delete".equals(j.getAuthorizationParameter())) {
+					throw new UJSAuthorizationException("fail delete req");
+				}
+			}
 		};
 		String user = "foo";
 		String user2 = "bar";

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTest.java
@@ -761,6 +761,8 @@ public class JSONRPCLayerTest extends JSONRPCLayerTestUtils {
 		InitProgress noprog = new InitProgress().withPtype("none");
 		String jobid = CLIENT1.createAndStartJob(TOKEN2, "d stat", "d desc", noprog, null);
 		CLIENT1.completeJob(jobid, TOKEN2, "d stat2", null, null);
+		failToDeleteJob(CLIENT2, jobid, String.format(
+				"There is no deletable job %s for user %s", jobid, USER2));
 		CLIENT1.deleteJob(jobid);
 		failGetJob(CLIENT1, jobid, String.format(nojob, jobid, USER1));
 		
@@ -770,6 +772,9 @@ public class JSONRPCLayerTest extends JSONRPCLayerTestUtils {
 		failGetJob(CLIENT1, jobid, String.format(nojob, jobid, USER1));
 		
 		jobid = CLIENT1.createAndStartJob(TOKEN2, "d2 stat", "d2 desc", noprog, null);
+		failToDeleteJob(CLIENT2, jobid, TOKEN2, String.format(
+				"There is no deletable job %s for user %s and service %s",
+				jobid, USER2, USER2));
 		CLIENT1.forceDeleteJob(TOKEN2, jobid);
 		failGetJob(CLIENT1, jobid, String.format(nojob, jobid, USER1));
 		
@@ -789,65 +794,39 @@ public class JSONRPCLayerTest extends JSONRPCLayerTestUtils {
 		failGetJob(CLIENT1, jobid, String.format(nojob, jobid, USER1));
 		
 		jobid = CLIENT1.createJob2(new CreateJobParams());
-		failToDeleteJob(jobid, String.format(
+		failToDeleteJob(CLIENT1, jobid, String.format(
 				"There is no deletable job %s for user %s", jobid, USER1));
-		failToDeleteJob(jobid, TOKEN2, String.format(
+		failToDeleteJob(CLIENT1, jobid, TOKEN2, String.format(
 				"There is no deletable job %s for user %s and service %s",
 				jobid, USER1, USER2));
 		CLIENT1.startJob(jobid, TOKEN2, "d6 stat", "d6 desc", noprog, null);
-		failToDeleteJob(jobid, String.format(
+		failToDeleteJob(CLIENT1, jobid, String.format(
 				"There is no deletable job %s for user %s", jobid, USER1));
 		CLIENT1.updateJobProgress(jobid, TOKEN2, "d6 stat2", 3L, null);
-		failToDeleteJob(jobid, String.format(
+		failToDeleteJob(CLIENT1, jobid, String.format(
 				"There is no deletable job %s for user %s", jobid, USER1));
 		
-		failToDeleteJob(null, "id cannot be null or the empty string");
-		failToDeleteJob("", "id cannot be null or the empty string");
-		failToDeleteJob("aaaaaaaaaaaaaaaaaaaa",
+		failToDeleteJob(CLIENT1, null, "id cannot be null or the empty string");
+		failToDeleteJob(CLIENT1, "", "id cannot be null or the empty string");
+		failToDeleteJob(CLIENT1, "aaaaaaaaaaaaaaaaaaaa",
 				"Job ID aaaaaaaaaaaaaaaaaaaa is not a legal ID");
 		
-		failToDeleteJob(null, TOKEN2,
+		failToDeleteJob(CLIENT1, null, TOKEN2,
 				"id cannot be null or the empty string");
-		failToDeleteJob("", TOKEN2,
+		failToDeleteJob(CLIENT1, "", TOKEN2,
 				"id cannot be null or the empty string");
-		failToDeleteJob("aaaaaaaaaaaaaaaaaaaa", TOKEN2,
+		failToDeleteJob(CLIENT1, "aaaaaaaaaaaaaaaaaaaa", TOKEN2,
 				"Job ID aaaaaaaaaaaaaaaaaaaa is not a legal ID");
 		
-		failToDeleteJob(jobid, null,
+		failToDeleteJob(CLIENT1, jobid, null,
 				"Service token cannot be null or the empty string", true);
-		failToDeleteJob(jobid, "foo",
+		failToDeleteJob(CLIENT1, jobid, "foo",
 				"Auth token is in the incorrect format, near 'foo'");
-		failToDeleteJob(jobid, TOKEN2 + 'w',
+		failToDeleteJob(CLIENT1, jobid, TOKEN2 + 'w',
 				"Service token is invalid");
-		failToDeleteJob(jobid, TOKEN1, String.format(
+		failToDeleteJob(CLIENT1, jobid, TOKEN1, String.format(
 				"There is no deletable job %s for user %s and service %s",
 				jobid, USER1, USER1));
-	}
-	
-	private void failToDeleteJob(String jobid, String exception)
-			throws Exception {
-		failToDeleteJob(jobid, null, exception, false);
-	}
-	
-	private void failToDeleteJob(String jobid, String token, String exception)
-			throws Exception {
-		failToDeleteJob(jobid, token, exception, false);
-	}
-	
-	private void failToDeleteJob(String jobid, String token, String exception,
-			boolean usenulltoken)
-			throws Exception {
-		try {
-			if (!usenulltoken && token == null) {
-				CLIENT1.deleteJob(jobid);
-			} else {
-				CLIENT1.forceDeleteJob(token, jobid);
-			}
-			fail("deleted job with bad args");
-		} catch (ServerException se) {
-			assertThat("correct exception", se.getLocalizedMessage(),
-					is(exception));
-		}
 	}
 	
 	@Test

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTest.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTest.java
@@ -790,16 +790,16 @@ public class JSONRPCLayerTest extends JSONRPCLayerTestUtils {
 		
 		jobid = CLIENT1.createJob2(new CreateJobParams());
 		failToDeleteJob(jobid, String.format(
-				"There is no completed job %s for user %s", jobid, USER1));
+				"There is no deletable job %s for user %s", jobid, USER1));
 		failToDeleteJob(jobid, TOKEN2, String.format(
-				"There is no job %s for user %s and service %s",
+				"There is no deletable job %s for user %s and service %s",
 				jobid, USER1, USER2));
 		CLIENT1.startJob(jobid, TOKEN2, "d6 stat", "d6 desc", noprog, null);
 		failToDeleteJob(jobid, String.format(
-				"There is no completed job %s for user %s", jobid, USER1));
+				"There is no deletable job %s for user %s", jobid, USER1));
 		CLIENT1.updateJobProgress(jobid, TOKEN2, "d6 stat2", 3L, null);
 		failToDeleteJob(jobid, String.format(
-				"There is no completed job %s for user %s", jobid, USER1));
+				"There is no deletable job %s for user %s", jobid, USER1));
 		
 		failToDeleteJob(null, "id cannot be null or the empty string");
 		failToDeleteJob("", "id cannot be null or the empty string");
@@ -820,7 +820,7 @@ public class JSONRPCLayerTest extends JSONRPCLayerTestUtils {
 		failToDeleteJob(jobid, TOKEN2 + 'w',
 				"Service token is invalid");
 		failToDeleteJob(jobid, TOKEN1, String.format(
-				"There is no job %s for user %s and service %s",
+				"There is no deletable job %s for user %s and service %s",
 				jobid, USER1, USER1));
 	}
 	

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTestUtils.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTestUtils.java
@@ -335,7 +335,7 @@ public class JSONRPCLayerTestUtils {
 		}
 	}
 
-	protected void failGetJob(UserAndJobStateClient cli, String jobid,
+	protected static void failGetJob(UserAndJobStateClient cli, String jobid,
 			String exception)
 			throws Exception {
 		try {
@@ -524,6 +524,37 @@ public class JSONRPCLayerTestUtils {
 			assertThat("correct exception", se.getMessage(), is(exception));
 		}
 		
+	}
+	
+	protected static void deleteJob(
+			final UserAndJobStateClient cli,
+			final String id)
+			throws Exception {
+		try {
+			cli.deleteJob(id);
+		} catch (ServerException se) {
+			System.out.println(se.getData());
+			throw se;
+		}
+		failGetJob(cli, id, String.format(
+				"There is no job %s viewable by user %s",
+				id, cli.getToken().getUserName()));
+	}
+	
+	protected static void deleteJob(
+			final UserAndJobStateClient cli,
+			final String id,
+			final String service)
+			throws Exception {
+		try {
+			cli.forceDeleteJob(service, id);
+		} catch (ServerException se) {
+			System.out.println(se.getData());
+			throw se;
+		}
+		failGetJob(cli, id, String.format(
+				"There is no job %s viewable by user %s",
+				id, cli.getToken().getUserName()));
 	}
 	
 	protected void failToDeleteJob(

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTestUtils.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTestUtils.java
@@ -525,6 +525,43 @@ public class JSONRPCLayerTestUtils {
 		}
 		
 	}
+	
+	protected void failToDeleteJob(
+			final UserAndJobStateClient cli,
+			final String jobid,
+			final String exception)
+			throws Exception {
+		failToDeleteJob(cli, jobid, null, exception, false);
+	}
+	
+	protected void failToDeleteJob(
+			final UserAndJobStateClient cli,
+			final String jobid,
+			final String token,
+			final String exception)
+			throws Exception {
+		failToDeleteJob(cli, jobid, token, exception, false);
+	}
+	
+	protected void failToDeleteJob(
+			final UserAndJobStateClient cli, 
+			final String jobid,
+			final String token,
+			final String exception,
+			boolean usenulltoken)
+			throws Exception {
+		try {
+			if (!usenulltoken && token == null) {
+				cli.deleteJob(jobid);
+			} else {
+				cli.forceDeleteJob(token, jobid);
+			}
+			fail("deleted job with bad args");
+		} catch (ServerException se) {
+			assertThat("correct exception", se.getLocalizedMessage(),
+					is(exception));
+		}
+	}
 
 	protected static void failCreateJob(UserAndJobStateClient cli,
 			String authstrat, String param, String exp)

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCWithWSAuth.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCWithWSAuth.java
@@ -365,35 +365,6 @@ public class JSONRPCWithWSAuth extends JSONRPCLayerTestUtils {
 		deleteJob(UJSC2, id2, TOKEN2);
 	}
 	
-	private void deleteJob(final UserAndJobStateClient cli, final String id)
-			throws Exception {
-		try {
-			cli.deleteJob(id);
-		} catch (ServerException se) {
-			System.out.println(se.getData());
-			throw se;
-		}
-		failGetJob(cli, id, String.format(
-				"There is no job %s viewable by user %s",
-				id, cli.getToken().getUserName()));
-	}
-	
-	private void deleteJob(
-			final UserAndJobStateClient cli,
-			final String id,
-			final String service)
-			throws Exception {
-		try {
-			cli.forceDeleteJob(service, id);
-		} catch (ServerException se) {
-			System.out.println(se.getData());
-			throw se;
-		}
-		failGetJob(cli, id, String.format(
-				"There is no job %s viewable by user %s",
-				id, cli.getToken().getUserName()));
-	}
-	
 	private String createStartedJob() throws Exception {
 		InitProgress noprog = new InitProgress().withPtype("none");
 		String id = UJSC1.createJob2(new CreateJobParams().withAuthstrat(KBWS)

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCWithWSAuth.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCWithWSAuth.java
@@ -197,28 +197,26 @@ public class JSONRPCWithWSAuth extends JSONRPCLayerTestUtils {
 	
 	@Test
 	public void testGetJob() throws Exception {
-		String user1 = U1.getUserId();
-		String user2 = U2.getUserId();
 		InitProgress noprog = new InitProgress().withPtype("none");
 		List<String> mtl = new LinkedList<String>();
 		
 		WSC1.createWorkspace(new CreateWorkspaceParams().withWorkspace("foo"));
-		setPermissions(WSC1, 1, "r", user2);
+		setPermissions(WSC1, 1, "r", USER2);
 		
 		//test that deleting a workspace keeps the job visible to the owner
 		String id =  UJSC1.createJob2(new CreateJobParams()
 			.withAuthstrat(KBWS).withAuthparam("1"));
 		checkJob(UJSC1, id, USER1, null, "created", null, null, null, null,
 				null, null, null, null, null, null, null, KBWS, "1", MTMAP);
-		assertThat("owner ok", UJSC1.getJobOwner(id), is(user1));
+		assertThat("owner ok", UJSC1.getJobOwner(id), is(USER1));
 		assertThat("shared list ok", UJSC1.getJobShared(id), is(mtl));
 		checkJob(UJSC2, id, USER1, null, "created", null, null, null, null,
 				null, null, null, null, null, null, null, KBWS, "1", MTMAP);
-		assertThat("owner ok", UJSC2.getJobOwner(id), is(user1));
+		assertThat("owner ok", UJSC2.getJobOwner(id), is(USER1));
 		
 		WSC1.deleteWorkspace(new WorkspaceIdentity().withId(1L));
 		final String err = String.format(
-				"There is no job %s viewable by user %s", id, user2);
+				"There is no job %s viewable by user %s", id, USER2);
 		failGetJob(UJSC2, id, err);
 		failGetJobOwner(UJSC2, id, err);
 		failGetJobShared(UJSC2, id, err);
@@ -226,43 +224,42 @@ public class JSONRPCWithWSAuth extends JSONRPCLayerTestUtils {
 		UJSC1.startJob(id, TOKEN2, "stat1", "desc1", noprog, null);
 		UJSC1.updateJob(id, TOKEN2, "up stat2", null);
 		UJSC1.completeJob(id, TOKEN2, "c stat2", null, null);
-		checkJob(UJSC1, id, USER1, null, "complete", "c stat2", user2, "desc1",
+		checkJob(UJSC1, id, USER1, null, "complete", "c stat2", USER2, "desc1",
 				"none", null, null, null, 1L, 0L, null, null, KBWS, "1", MTMAP);
-		assertThat("owner ok", UJSC1.getJobOwner(id), is(user1));
+		assertThat("owner ok", UJSC1.getJobOwner(id), is(USER1));
 		assertThat("shared list ok", UJSC1.getJobShared(id), is(mtl));
 		
 		WSC1.undeleteWorkspace(new WorkspaceIdentity().withId(1L));
-		checkJob(UJSC2, id, USER1, null, "complete", "c stat2", user2, "desc1",
+		checkJob(UJSC2, id, USER1, null, "complete", "c stat2", USER2, "desc1",
 				"none", null, null, null, 1L, 0L, null, null, KBWS, "1", MTMAP);
-		assertThat("owner ok", UJSC2.getJobOwner(id), is(user1));
+		assertThat("owner ok", UJSC2.getJobOwner(id), is(USER1));
 		
-		setPermissions(WSC1, 1, "n", user2);
+		setPermissions(WSC1, 1, "n", USER2);
 		failGetJob(UJSC2, id, err);
 		failGetJobOwner(UJSC2, id, err);
 		failGetJobShared(UJSC2, id, err);
 		
-		setPermissions(WSC1, 1, "w", user2);
-		checkJob(UJSC2, id, USER1, null, "complete", "c stat2", user2, "desc1",
+		setPermissions(WSC1, 1, "w", USER2);
+		checkJob(UJSC2, id, USER1, null, "complete", "c stat2", USER2, "desc1",
 				"none", null, null, null, 1L, 0L, null, null, KBWS, "1", MTMAP);
-		assertThat("owner ok", UJSC2.getJobOwner(id), is(user1));
+		assertThat("owner ok", UJSC2.getJobOwner(id), is(USER1));
 		
-		setPermissions(WSC1, 1, "a", user2);
-		checkJob(UJSC2, id, USER1, null, "complete", "c stat2", user2, "desc1",
+		setPermissions(WSC1, 1, "a", USER2);
+		checkJob(UJSC2, id, USER1, null, "complete", "c stat2", USER2, "desc1",
 				"none", null, null, null, 1L, 0L, null, null, KBWS, "1", MTMAP);
-		assertThat("owner ok", UJSC2.getJobOwner(id), is(user1));
+		assertThat("owner ok", UJSC2.getJobOwner(id), is(USER1));
 		
 	}
 	
 	@Test
 	public void testCancelJob() throws Exception {
-		String user2 = U2.getUserId();
 		
 		WSC1.createWorkspace(new CreateWorkspaceParams()
 				.withWorkspace("foo"));
-		setPermissions(WSC1, 1, "w", user2);
+		setPermissions(WSC1, 1, "w", USER2);
 		
 		//test that deleting a workspace keeps the job visible to the owner
-		String id = createJobForCancel();
+		String id = createStartedJob();
 		try {
 			UJSC2.cancelJob(id, "canceled1");
 		} catch (ServerException se) {
@@ -272,12 +269,12 @@ public class JSONRPCWithWSAuth extends JSONRPCLayerTestUtils {
 		checkJob(UJSC1, id, USER1, USER2, "canceled", "canceled1", USER2,
 				"desc", "none", null, null, null, 1L, 0L, null, null, KBWS,
 				"1", MTMAP);
-		id = createJobForCancel();
-		String id2 = createJobForCancel();
+		id = createStartedJob();
+		String id2 = createStartedJob();
 		WSC1.deleteWorkspace(new WorkspaceIdentity().withId(1L));
 		String err = String.format(
 				"There is no job %s that may be canceled by user %s", id,
-				user2);
+				USER2);
 		failCancelJob(UJSC2, id, "cancel", err);
 		checkJob(UJSC1, id, USER1, null, "started", "stat", USER2,
 				"desc", "none", null, null, null, 0L, 0L, null, null, KBWS,
@@ -292,28 +289,125 @@ public class JSONRPCWithWSAuth extends JSONRPCLayerTestUtils {
 				"desc", "none", null, null, null, 1L, 0L, null, null, KBWS,
 				"1", MTMAP);
 		
-		id = createJobForCancel();
+		id = createStartedJob();
 		err = String.format(
 				"There is no job %s that may be canceled by user %s", id,
-				user2);
-		setPermissions(WSC1, 1, "n", user2);
+				USER2);
+		setPermissions(WSC1, 1, "n", USER2);
 		failCancelJob(UJSC2, id, "c", err);
 		
-		setPermissions(WSC1, 1, "r", user2);
+		setPermissions(WSC1, 1, "r", USER2);
 		failCancelJob(UJSC2, id, "c", err);
 		
-		setPermissions(WSC1, 1, "a", user2);
+		setPermissions(WSC1, 1, "a", USER2);
 		UJSC2.cancelJob(id, "cancel4");
 		checkJob(UJSC1, id, USER1, USER2, "canceled", "cancel4", USER2,
 				"desc", "none", null, null, null, 1L, 0L, null, null, KBWS,
 				"1", MTMAP);
 	}
 
-	private String createJobForCancel() throws Exception {
+	@Test
+	public void testDeleteJob() throws Exception {
+		
+		WSC1.createWorkspace(new CreateWorkspaceParams()
+				.withWorkspace("foo"));
+		setPermissions(WSC1, 1, "a", USER2);
+		
+		//test that deleting a workspace keeps the job visible to the owner
+		String id = createCompletedJob();
+		deleteJob(UJSC2, id);
+		id = createStartedJob();
+		deleteJob(UJSC2, id, TOKEN2);
+		id = createCompletedJob();
+		String id2 = createStartedJob();
+		String id3 = createCompletedJob();
+		String id4 = createStartedJob();
+		WSC1.deleteWorkspace(new WorkspaceIdentity().withId(1L));
+		failToDeleteJob(UJSC2, id, String.format(
+				"There is no deletable job %s for user %s", id,
+				USER2));
+		failToDeleteJob(UJSC2, id2, TOKEN2, String.format(
+				"There is no deletable job %s for user %s and service %s", id2,
+				USER2, USER2));
+
+		deleteJob(UJSC1, id3);
+		deleteJob(UJSC1, id4, TOKEN2);
+		WSC1.undeleteWorkspace(new WorkspaceIdentity().withId(1L));
+		failGetJob(UJSC1, id3, String.format(
+				"There is no job %s viewable by user %s",
+				id3, USER1));
+		failGetJob(UJSC1, id4, String.format(
+				"There is no job %s viewable by user %s",
+				id4, USER1));
+		deleteJob(UJSC2, id);
+		deleteJob(UJSC2, id2, TOKEN2);
+		
+		id = createCompletedJob();
+		id2 = createStartedJob();
+		String es = "There is no deletable job %s for user %s";
+		String err1 = String.format(es, id, USER2);
+		String err2 = String.format(es, id2, USER2) + " and service " + USER2;
+
+		setPermissions(WSC1, 1, "n", USER2);
+		failToDeleteJob(UJSC2, id, err1);
+		failToDeleteJob(UJSC2, id2, TOKEN2, err2);
+		
+		setPermissions(WSC1, 1, "r", USER2);
+		failToDeleteJob(UJSC2, id, err1);
+		failToDeleteJob(UJSC2, id2, TOKEN2, err2);
+		
+		setPermissions(WSC1, 1, "w", USER2);
+		failToDeleteJob(UJSC2, id, err1);
+		failToDeleteJob(UJSC2, id2, TOKEN2, err2);
+		
+		setPermissions(WSC1, 1, "a", USER2);
+		deleteJob(UJSC2, id);
+		deleteJob(UJSC2, id2, TOKEN2);
+	}
+	
+	private void deleteJob(final UserAndJobStateClient cli, final String id)
+			throws Exception {
+		try {
+			cli.deleteJob(id);
+		} catch (ServerException se) {
+			System.out.println(se.getData());
+			throw se;
+		}
+		failGetJob(cli, id, String.format(
+				"There is no job %s viewable by user %s",
+				id, cli.getToken().getUserName()));
+	}
+	
+	private void deleteJob(
+			final UserAndJobStateClient cli,
+			final String id,
+			final String service)
+			throws Exception {
+		try {
+			cli.forceDeleteJob(service, id);
+		} catch (ServerException se) {
+			System.out.println(se.getData());
+			throw se;
+		}
+		failGetJob(cli, id, String.format(
+				"There is no job %s viewable by user %s",
+				id, cli.getToken().getUserName()));
+	}
+	
+	private String createStartedJob() throws Exception {
 		InitProgress noprog = new InitProgress().withPtype("none");
 		String id = UJSC1.createJob2(new CreateJobParams().withAuthstrat(KBWS)
 				.withAuthparam("1"));
 		UJSC1.startJob(id, TOKEN2, "stat", "desc", noprog, null);
+		return id;
+	}
+	
+	private String createCompletedJob() throws Exception {
+		InitProgress noprog = new InitProgress().withPtype("none");
+		String id = UJSC1.createJob2(new CreateJobParams().withAuthstrat(KBWS)
+				.withAuthparam("1"));
+		UJSC1.startJob(id, TOKEN2, "stat", "desc", noprog, null);
+		UJSC1.completeJob(id, TOKEN2, "comp", null, null);
 		return id;
 	}
 

--- a/src/us/kbase/userandjobstate/test/kbase/WorkspaceAuthTest.java
+++ b/src/us/kbase/userandjobstate/test/kbase/WorkspaceAuthTest.java
@@ -156,7 +156,6 @@ public class WorkspaceAuthTest {
 			
 		}
 		
-		//TODO NOW TEST
 		@Override
 		protected void externallyAuthorizeDelete(String user, Job j)
 				throws UJSAuthorizationException {
@@ -319,7 +318,7 @@ public class WorkspaceAuthTest {
 		failCancel(wa2, user2, j, new UJSAuthorizationException(
 				String.format("User %s cannot write to workspace 1", user2)));
 		JSONRPCLayerTestUtils.setPermissions(WSC1, 1, "a", user2);
-		wa2.authorizeRead(user2, j);
+		wa2.authorizeCancel(user2, j);
 		
 		failCancel(wa2, user1, j, new IllegalStateException(
 				"A programming error occured: the token username and the " +
@@ -333,6 +332,74 @@ public class WorkspaceAuthTest {
 				"Invalid authorization strategy: foo"));
 	}
 	
+	@Test
+	public void testDelete() throws Exception {
+		WorkspaceAuthorizationFactory wafac =
+				new WorkspaceAuthorizationFactory(
+						new URL("http://localhost:" + WS.getServerPort()));
+		UJSAuthorizer wa1 = wafac.buildAuthorizer(U1.getToken());
+		UJSAuthorizer wa2 = wafac.buildAuthorizer(U2.getToken());
+		String user1 = U1.getUserId();
+		String user2 = U2.getUserId();
+		
+		WSC1.createWorkspace(new CreateWorkspaceParams()
+				.withWorkspace("foo"));
+		JSONRPCLayerTestUtils.setPermissions(WSC1, 1, "a", user2);
+		WorkspaceUserMetadata mt = new WorkspaceUserMetadata();
+		
+		//test that deleting a workspace keeps the job visible to the owner
+		String id = JS.createJob(user1, wa1, strat, "1", mt);
+		Job j = JS.getJob(user1, id, wa1);
+		wa2.authorizeDelete(user2, j);
+		WSC1.deleteWorkspace(new WorkspaceIdentity().withId(1L));
+		failDelete(wa2, user2, j, new UJSAuthorizationException(
+				"Error contacting the workspace service to get permissions: " +
+				"Workspace 1 is deleted"));
+		wa1.authorizeDelete(user1, j);
+		WSC1.undeleteWorkspace(new WorkspaceIdentity().withId(1L));
+		wa2.authorizeDelete(user2, j);
+		
+		JSONRPCLayerTestUtils.setPermissions(WSC1, 1, "n", user2);
+		failDelete(wa2, user2, j, new UJSAuthorizationException(String.format(
+				"User %s does not have administration privileges for " +
+				"workspace 1", user2)));
+		JSONRPCLayerTestUtils.setPermissions(WSC1, 1, "r", user2);
+		failDelete(wa2, user2, j, new UJSAuthorizationException(String.format(
+				"User %s does not have administration privileges for " +
+				"workspace 1", user2)));;
+		JSONRPCLayerTestUtils.setPermissions(WSC1, 1, "w", user2);
+		failDelete(wa2, user2, j, new UJSAuthorizationException(String.format(
+				"User %s does not have administration privileges for " +
+				"workspace 1", user2)));;
+		JSONRPCLayerTestUtils.setPermissions(WSC1, 1, "a", user2);
+		wa2.authorizeDelete(user2, j);
+		
+		
+		failDelete(wa2, user1, j, new IllegalStateException(
+				"A programming error occured: the token username and the " +
+				"supplied username do not match"));
+		
+		// test bad auth strat
+		String id2 = JS.createJob(user1, LENIENT,
+				new AuthorizationStrategy("foo"), "foo", mt);
+		Job j2 = JS.getJob(user1, id2, LENIENT);
+		failDelete(wa1, user1, j2, new UJSAuthorizationException(
+				"Invalid authorization strategy: foo"));
+	}
+	
+	private void failDelete(
+			final UJSAuthorizer auth,
+			final String user,
+			final Job j,
+			final Exception exp) {
+		try {
+			auth.authorizeDelete(user, j);
+			fail("authorized bad delete");
+		} catch (Exception got) {
+			assertExceptionCorrect(got, exp);
+		}
+	}
+
 	private void failCancel(
 			final UJSAuthorizer auth,
 			final String user,

--- a/src/us/kbase/userandjobstate/test/kbase/WorkspaceAuthTest.java
+++ b/src/us/kbase/userandjobstate/test/kbase/WorkspaceAuthTest.java
@@ -155,6 +155,14 @@ public class WorkspaceAuthTest {
 			throw new UnimplementedException();
 			
 		}
+		
+		//TODO NOW TEST
+		@Override
+		protected void externallyAuthorizeDelete(String user, Job j)
+				throws UJSAuthorizationException {
+			throw new UnimplementedException();
+			
+		}
 	};
 	
 	@Test


### PR DESCRIPTION
As of the first commit:
Implemented in authorizer base class, default authorizer, UJS server
fallback authorizer, workspace authorizer, and test authorizers.

Changes to base class & default authorizer are tested.

TODO:
- [x] implement authorizer in delete method
- [x] test authorizer in jobstatetests
- [x] test workspaceauthorizer in workspaceauthtest
- [x] test new auth in jsonrpclayertest
- [x] test new auth in jsonrpcwithwsauth
- [x] test new auth in pullwsjobwithoutwstest
