### PR TITLE
Ignore whitespace for mongo user & pwd

### DIFF
--- a/src/us/kbase/userandjobstate/UserAndJobStateServer.java
+++ b/src/us/kbase/userandjobstate/UserAndJobStateServer.java
@@ -593,7 +593,11 @@ public class UserAndJobStateServer extends JsonServerServlet {
 			final Map<String, String> config,
 			final String param) {
 		final String p = config.get(param);
-		return p != null && !p.isEmpty();
+		return p != null && !p.trim().isEmpty();
+	}
+	
+	private String nullIfWhitespace(final String s) {
+		return s == null || s.trim().isEmpty() ? null : s.trim();
 	}
 	
 	public static void clearConfigForTests() {
@@ -650,8 +654,8 @@ public class UserAndJobStateServer extends JsonServerServlet {
 			auth = null;
 			authfac = null;
 		} else {
-			final String user = ujConfig.get(USER);
-			final String pwd = ujConfig.get(PWD);
+			final String user = nullIfWhitespace(ujConfig.get(USER));
+			final String pwd = nullIfWhitespace(ujConfig.get(PWD));
 			final String authAllowInsecure = ujConfig.get(INSECURE_AUTH_URL);
 			String params = "";
 			for (String s: Arrays.asList(HOST, DB, USER, KBASE_AUTH_URL,

--- a/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTestUtils.java
+++ b/src/us/kbase/userandjobstate/test/kbase/JSONRPCLayerTestUtils.java
@@ -80,7 +80,7 @@ public class JSONRPCLayerTestUtils {
 		Section ws = ini.add("UserAndJobState");
 		ws.add("mongodb-host", mongohost);
 		ws.add("mongodb-database", dbname);
-		ws.add("mongodb-user", null);
+		ws.add("mongodb-user", "     "); // test that whitespace is ignored
 		ws.add("mongodb-pwd", null);
 		ws.add("auth-service-url", authURL + "/api/legacy/KBase/Sessions/Login");
 		ws.add("auth-service-url-allow-insecure", "true");


### PR DESCRIPTION
Previously would try and auth with whitespace, which apparently the
previous mongo client wouldn't care about